### PR TITLE
TX error monitor orchagent

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -127,7 +127,8 @@ orchagent_SOURCES = \
             dash/dashportmaporch.cpp \
             twamporch.cpp \
             stporch.cpp \
-            nexthopkey.cpp
+            nexthopkey.cpp \
+            txerrororch.cpp
 
 orchagent_SOURCES += flex_counter/flex_counter_manager.cpp flex_counter/flex_counter_stat_manager.cpp flex_counter/flow_counter_handler.cpp flex_counter/flowcounterrouteorch.cpp
 orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.cpp

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -13,7 +13,6 @@
 #include "sairedis.h"
 #include "chassisorch.h"
 #include "stporch.h"
-#include "schema.h"
 
 using namespace std;
 using namespace swss;
@@ -463,11 +462,7 @@ bool OrchDaemon::init()
 
     gNhgMapOrch = new NhgMapOrch(m_applDb, APP_FC_TO_NHG_INDEX_MAP_TABLE_NAME);
 
-    vector<string> tx_error_config_tables = {
-        CFG_TX_ERROR_MONITOR_TABLE_NAME
-    };
-
-    gTxErrorOrch = new TxErrorOrch(m_configDb, m_stateDb, tx_error_config_tables);
+    gTxErrorOrch = new TxErrorOrch(m_configDb, m_stateDb, CFG_TX_ERROR_MONITOR_TABLE_NAME);
 
     /*
      * The order of the orch list is important for state restore of warm start and

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -13,6 +13,7 @@
 #include "sairedis.h"
 #include "chassisorch.h"
 #include "stporch.h"
+#include "schema.h"
 
 using namespace std;
 using namespace swss;
@@ -67,6 +68,7 @@ TunnelDecapOrch *gTunneldecapOrch;
 StpOrch *gStpOrch;
 MuxOrch *gMuxOrch;
 IcmpOrch *gIcmpOrch;
+TxErrorOrch *gTxErrorOrch;
 
 bool gIsNatSupported = false;
 event_handle_t g_events_handle;
@@ -461,6 +463,12 @@ bool OrchDaemon::init()
 
     gNhgMapOrch = new NhgMapOrch(m_applDb, APP_FC_TO_NHG_INDEX_MAP_TABLE_NAME);
 
+    vector<string> tx_error_config_tables = {
+        CFG_TX_ERROR_MONITOR_TABLE_NAME
+    };
+
+    gTxErrorOrch = new TxErrorOrch(m_configDb, m_stateDb, tx_error_config_tables);
+
     /*
      * The order of the orch list is important for state restore of warm start and
      * the queued processing in m_toSync map after gPortsOrch->allPortsReady() is set.
@@ -469,7 +477,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gFgNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, gTunneldecapOrch, sflow_orch, gDebugCounterOrch, gMacsecOrch, bgp_global_state_orch, gBfdOrch, gIcmpOrch, gSrv6Orch, gMuxOrch, mux_cb_orch, gMonitorOrch, gStpOrch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gFgNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, gTunneldecapOrch, sflow_orch, gDebugCounterOrch, gMacsecOrch, bgp_global_state_orch, gBfdOrch, gIcmpOrch, gSrv6Orch, gMuxOrch, mux_cb_orch, gMonitorOrch, gStpOrch ,gTxErrorOrch};
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -49,6 +49,7 @@
 #include "nvgreorch.h"
 #include "twamporch.h"
 #include "stporch.h"
+#include "txerrororch.h"
 #include "dash/dashenifwdorch.h"
 #include "dash/dashaclorch.h"
 #include "dash/dashorch.h"

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -8,6 +8,7 @@
 #include "subintf.h"
 #include "notifications.h"
 #include "stporch.h"
+#include "txerrororch.h"
 
 #include <inttypes.h>
 #include <cassert>
@@ -58,6 +59,7 @@ extern BufferOrch *gBufferOrch;
 extern FdbOrch *gFdbOrch;
 extern SwitchOrch *gSwitchOrch;
 extern StpOrch *gStpOrch;
+extern TxErrorOrch *gTxErrorOrch;
 extern Directory<Orch*> gDirectory;
 extern sai_system_port_api_t *sai_system_port_api;
 extern string gMySwitchType;
@@ -6280,6 +6282,13 @@ bool PortsOrch::initializePort(Port &port)
 
         SWSS_LOG_DEBUG("Received host_tx_ready current status: port_id: 0x%" PRIx64 " status: %s", port.m_port_id, hostTxReadyStr.c_str());
         setHostTxReady(port, hostTxReadyStr);
+    }
+
+    // Initialize TX error state for physical ports
+    if (port.m_type == Port::PHY && gTxErrorOrch != nullptr)
+    {
+        gTxErrorOrch->initializePortState(port.m_alias);
+        SWSS_LOG_NOTICE("Initialized TX error state for port %s", port.m_alias.c_str());
     }
 
     return true;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -8,7 +8,6 @@
 #include "subintf.h"
 #include "notifications.h"
 #include "stporch.h"
-#include "txerrororch.h"
 
 #include <inttypes.h>
 #include <cassert>
@@ -59,7 +58,6 @@ extern BufferOrch *gBufferOrch;
 extern FdbOrch *gFdbOrch;
 extern SwitchOrch *gSwitchOrch;
 extern StpOrch *gStpOrch;
-extern TxErrorOrch *gTxErrorOrch;
 extern Directory<Orch*> gDirectory;
 extern sai_system_port_api_t *sai_system_port_api;
 extern string gMySwitchType;
@@ -6285,9 +6283,14 @@ bool PortsOrch::initializePort(Port &port)
     }
 
     // Initialize TX error state for physical ports
-    if (port.m_type == Port::PHY && gTxErrorOrch != nullptr)
+    if (port.m_type == Port::PHY)
     {
-        gTxErrorOrch->initializePortState(port.m_alias);
+        Table stateTable(m_state_db.get(), STATE_TX_ERROR_TABLE_NAME);
+        vector<FieldValueTuple> fieldValues;
+        fieldValues.emplace_back("status", "OK");
+        stateTable.set(port.m_alias, fieldValues);
+        
+        SWSS_LOG_NOTICE("Initialized TX error state for port %s to OK", port.m_alias.c_str());
     }
 
     return true;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6288,7 +6288,6 @@ bool PortsOrch::initializePort(Port &port)
     if (port.m_type == Port::PHY && gTxErrorOrch != nullptr)
     {
         gTxErrorOrch->initializePortState(port.m_alias);
-        SWSS_LOG_NOTICE("Initialized TX error state for port %s", port.m_alias.c_str());
     }
 
     return true;

--- a/orchagent/txerrororch.cpp
+++ b/orchagent/txerrororch.cpp
@@ -1,0 +1,236 @@
+#include "txerrororch.h"
+#include "timer.h"
+#include "logger.h"
+#include "schema.h"
+#include "portsorch.h"
+#include "sai_serialize.h"
+#include "portsorch.h"
+#include <tuple>
+#include <vector>
+
+extern PortsOrch *gPortsOrch;
+
+TxErrorOrch::TxErrorOrch(DBConnector *configDb, DBConnector *stateDb,const std::vector<std::string> &tableNames) :
+    Orch(configDb, tableNames),
+    m_stateDb(stateDb),
+    m_countersDb(new DBConnector("COUNTERS_DB", 0)),
+    m_stateTable(new Table(m_stateDb, STATE_TX_ERROR_TABLE_NAME)),
+    m_countersTable(new Table(m_countersDb.get(), COUNTERS_TABLE))
+{
+
+    SWSS_LOG_ENTER();
+
+    auto interv = timespec { .tv_sec = DEFAULT_POLL_INTERVAL_SEC, .tv_nsec = 0 };
+    m_timer = new SelectableTimer(interv);
+    m_executor = new ExecutableTimer(m_timer, this, "TX_ERROR_POLL");
+    Orch::addExecutor(m_executor);
+    m_timer->start();
+
+    m_pollInterval = DEFAULT_POLL_INTERVAL_SEC;
+    m_threshold = DEFAULT_THRESHOLD;
+    
+}
+
+TxErrorOrch::~TxErrorOrch(void)
+{
+    SWSS_LOG_ENTER();
+
+    if (m_timer) {
+        m_timer->stop();
+        delete m_timer;
+        m_timer = nullptr;
+    }
+    
+    if (m_executor) {
+        delete m_executor;
+        m_executor = nullptr;
+    }
+}
+
+
+// Initialize port state to OK in state table
+void TxErrorOrch::initializePortState(const std::string &portAlias)
+{
+    SWSS_LOG_ENTER();
+    
+    vector<FieldValueTuple> fieldValues;
+    fieldValues.emplace_back("status", "OK");
+    
+    m_stateTable->set(portAlias, fieldValues);
+    
+    SWSS_LOG_INFO("Initialized tx error state for port %s", portAlias.c_str());
+}
+
+// Handle configuration changes to tx_error_monitor table (poll_interval, threshold)
+void TxErrorOrch::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("TX Error Consumer doTask called, queue size: %zu", consumer.m_toSync.size());
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        bool erase_from_queue = true;
+        try
+        {
+            auto tuple = it->second;
+            string key = kfvKey(tuple);
+            string op = kfvOp(tuple);
+
+            if(op == SET_COMMAND)
+            {
+                auto data = kfvFieldsValues(tuple);
+                for (const auto& fv : data)
+                {
+                    if (fvField(fv) == "poll_interval")   
+                    {
+                        int interval = std::stoi(fvValue(fv));
+                        if(interval<= 0)
+                        {
+                            SWSS_LOG_ERROR("Invalid poll_interval value, current interval value %d", m_pollInterval);
+                        }
+                        else
+                        {
+                            m_pollInterval = interval;
+                            SWSS_LOG_NOTICE("TX Error polling interval set to %d seconds", m_pollInterval);
+                            updateTimer(m_pollInterval);
+                        }
+                    }
+                    else if (fvField(fv) == "threshold")
+                    {
+                        int threshold = std::stoi(fvValue(fv));
+                        if(threshold<= 0)
+                        {
+                            SWSS_LOG_ERROR("Invalid threshold value, current threshold value %d", m_threshold);
+                        }
+                        else
+                        {
+                            m_threshold = threshold;
+                            SWSS_LOG_NOTICE("TX Error threshold set to %d", m_threshold);
+                        }
+                    }
+                }
+            }
+
+            //optional - fix If a del command is addad to the cli
+            else if (op == DEL_COMMAND)
+            {
+                m_pollInterval = DEFAULT_POLL_INTERVAL_SEC;
+                m_threshold = DEFAULT_THRESHOLD;
+            }
+
+        }
+        catch (const std::exception& e)
+        {
+            SWSS_LOG_ERROR("Exception was caught in the request parser in %s: %s", typeid(*this).name(), e.what());
+        }
+        catch (...)
+        {
+            SWSS_LOG_ERROR("Unknown exception was caught in the request parser");
+        }
+
+
+        if (erase_from_queue)
+        {
+            it = consumer.m_toSync.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+void TxErrorOrch::updateTimer(int interval)
+{
+    SWSS_LOG_ENTER();
+
+    m_timer->stop();
+
+    auto interv = timespec { .tv_sec = interval, .tv_nsec = 0 };
+    m_timer->setInterval(interv);
+    m_timer->reset();
+    m_timer->start();
+}
+
+// Timer callback: check TX error counters for all ports
+void TxErrorOrch::doTask(swss::SelectableTimer &timer)
+{
+    SWSS_LOG_ENTER();
+
+    for (const auto& portPair : gPortsOrch->getAllPorts())
+    {
+        txErrorCounterCheck(portPair.second);
+    }
+}
+
+// Check TX error counter for a port and update status if threshold exceeded
+void TxErrorOrch::txErrorCounterCheck(const Port& port)
+{
+    SWSS_LOG_ENTER();
+
+    if(port.m_type != Port::PHY) 
+        return;
+
+    sai_object_id_t oid = port.m_port_id;
+
+    vector<FieldValueTuple> fieldValues;
+
+    if(!m_countersTable->get(sai_serialize_object_id(oid), fieldValues)){
+        SWSS_LOG_ERROR("Failed to get tx error counters for port %s", port.m_alias.c_str());
+        return;
+    }
+
+    uint64_t tx_errors = 0;
+    for(const auto& fv : fieldValues)
+    {
+        if(fvField(fv) =="SAI_PORT_STAT_IF_OUT_ERRORS")
+        {
+            tx_errors = std::stoull(fvValue(fv));
+            break;
+        }
+    }
+
+    if(tx_errors > static_cast<uint64_t>(m_threshold))
+    {
+        SWSS_LOG_NOTICE("TX Error counters for port %s exceeded threshold: %ld > %d", 
+            port.m_alias.c_str(), tx_errors, m_threshold);
+        updatePortStatusNotOk(port);
+    }
+
+    else if(tx_errors <= static_cast<uint64_t>(m_threshold))
+    {
+        SWSS_LOG_NOTICE("TX Error counters for port %s is below threshold: %ld <= %d", 
+            port.m_alias.c_str(), tx_errors, m_threshold);
+        updatePortStatusOk(port);
+    }
+}
+
+// Mark port status as NOT_OK in state table
+void TxErrorOrch::updatePortStatusNotOk(const Port& port)
+{
+    SWSS_LOG_ENTER();
+
+    vector<FieldValueTuple> fieldValues;
+ 
+    fieldValues.emplace_back("status", "NOT_OK");
+    m_stateTable->set(port.m_alias, fieldValues);
+
+    SWSS_LOG_NOTICE("Marking port %s (OID: %s) as NOT_OK", port.m_alias.c_str(),
+                    sai_serialize_object_id(port.m_port_id).c_str());
+}
+
+// Mark port status as OK in state table
+void TxErrorOrch::updatePortStatusOk(const Port& port)
+{
+    SWSS_LOG_ENTER();
+
+    vector<FieldValueTuple> fieldValues;
+ 
+    fieldValues.emplace_back("status", "OK");
+    m_stateTable->set(port.m_alias, fieldValues);
+
+    SWSS_LOG_NOTICE("Marking port %s (OID: %s) as OK", port.m_alias.c_str(),
+                    sai_serialize_object_id(port.m_port_id).c_str());
+}

--- a/orchagent/txerrororch.cpp
+++ b/orchagent/txerrororch.cpp
@@ -13,9 +13,8 @@ extern PortsOrch *gPortsOrch;
 
 TxErrorOrch::TxErrorOrch(DBConnector *configDb, DBConnector *stateDb, string tableName) :
     Orch(configDb,tableName),
-    m_stateDb(stateDb),
     m_countersDb(new DBConnector("COUNTERS_DB", 0)),
-    m_stateTable(new Table(m_stateDb, STATE_TX_ERROR_TABLE_NAME)),
+    m_stateTable(new Table(stateDb, STATE_TX_ERROR_TABLE_NAME)),
     m_countersTable(new Table(m_countersDb.get(), COUNTERS_TABLE)),
     m_configTable(new Table(configDb, CFG_TX_ERROR_MONITOR_TABLE_NAME))
 {
@@ -62,19 +61,6 @@ void TxErrorOrch::InitializeMonitorConfiguration()
     m_configTable->set("global", fieldValues);
 
     SWSS_LOG_INFO("Written default TX error monitor configuration to CONFIG_DB");
-}
-
-// Initialize port state to OK in state table
-void TxErrorOrch::initializePortState(const std::string &portAlias)
-{
-    SWSS_LOG_ENTER();
-    
-    vector<FieldValueTuple> fieldValues;
-    fieldValues.emplace_back("status", "OK");
-    
-    m_stateTable->set(portAlias, fieldValues);
-    
-    SWSS_LOG_INFO("Initialized tx error state for port %s", portAlias.c_str());
 }
 
 // Handle configuration changes to tx_error_monitor table (poll_interval, threshold)
@@ -138,6 +124,7 @@ void TxErrorOrch::doTask(swss::SelectableTimer &timer)
     txErrorCountersCheck();
 }
   
+// Check TX error counters for all ports
 void TxErrorOrch::txErrorCountersCheck()
 {
     SWSS_LOG_ENTER();
@@ -173,15 +160,23 @@ void TxErrorOrch::txErrorCountersCheck()
 
         if (tx_errors > static_cast<uint64_t>(m_threshold))
         {
-            SWSS_LOG_DEBUG("TX Error counters for port %s exceeded threshold: %ld > %d", 
-                port.m_alias.c_str(), tx_errors, m_threshold);
-            updatePortStatus(port, "NOT_OK");
+            if(m_portStateMap.find(oid) == m_portStateMap.end() || m_portStateMap[oid] == "OK")
+            {
+                SWSS_LOG_DEBUG("TX Error counters for port %s exceeded threshold: %ld > %d", 
+                    port.m_alias.c_str(), tx_errors, m_threshold);
+                updatePortStatus(port, "NOT_OK");
+                m_portStateMap[oid] = "NOT_OK";
+            }
         }
         else if (tx_errors <= static_cast<uint64_t>(m_threshold))
         {
-            SWSS_LOG_DEBUG("TX Error counters for port %s is below threshold: %ld <= %d", 
-                port.m_alias.c_str(), tx_errors, m_threshold);
-            updatePortStatus(port, "OK");
+            if(m_portStateMap.find(oid) == m_portStateMap.end() || m_portStateMap[oid] == "NOT_OK")
+            {
+                SWSS_LOG_DEBUG("TX Error counters for port %s is below threshold: %ld <= %d", 
+                    port.m_alias.c_str(), tx_errors, m_threshold);
+                updatePortStatus(port, "OK");
+                m_portStateMap[oid] = "OK";
+            }
         }
     }
 }

--- a/orchagent/txerrororch.cpp
+++ b/orchagent/txerrororch.cpp
@@ -7,28 +7,30 @@
 #include "portsorch.h"
 #include <tuple>
 #include <vector>
+#include <unistd.h>
 
 extern PortsOrch *gPortsOrch;
 
-TxErrorOrch::TxErrorOrch(DBConnector *configDb, DBConnector *stateDb,const std::vector<std::string> &tableNames) :
-    Orch(configDb, tableNames),
+TxErrorOrch::TxErrorOrch(DBConnector *configDb, DBConnector *stateDb, string tableName) :
+    Orch(configDb,tableName),
     m_stateDb(stateDb),
     m_countersDb(new DBConnector("COUNTERS_DB", 0)),
     m_stateTable(new Table(m_stateDb, STATE_TX_ERROR_TABLE_NAME)),
-    m_countersTable(new Table(m_countersDb.get(), COUNTERS_TABLE))
+    m_countersTable(new Table(m_countersDb.get(), COUNTERS_TABLE)),
+    m_configTable(new Table(configDb, CFG_TX_ERROR_MONITOR_TABLE_NAME))
 {
-
     SWSS_LOG_ENTER();
+
+    m_pollInterval = DEFAULT_POLL_INTERVAL_SEC;
+    m_threshold = DEFAULT_THRESHOLD;
+
+    InitializeMonitorConfiguration();
 
     auto interv = timespec { .tv_sec = DEFAULT_POLL_INTERVAL_SEC, .tv_nsec = 0 };
     m_timer = new SelectableTimer(interv);
     m_executor = new ExecutableTimer(m_timer, this, "TX_ERROR_POLL");
     Orch::addExecutor(m_executor);
     m_timer->start();
-
-    m_pollInterval = DEFAULT_POLL_INTERVAL_SEC;
-    m_threshold = DEFAULT_THRESHOLD;
-    
 }
 
 TxErrorOrch::~TxErrorOrch(void)
@@ -47,6 +49,20 @@ TxErrorOrch::~TxErrorOrch(void)
     }
 }
 
+// Initialize monitor configuration in config table
+void TxErrorOrch::InitializeMonitorConfiguration()
+{
+    SWSS_LOG_ENTER();
+
+    vector<FieldValueTuple> fieldValues;
+
+    fieldValues.emplace_back("poll_interval", to_string(m_pollInterval));
+    fieldValues.emplace_back("threshold", to_string(m_threshold));
+
+    m_configTable->set("global", fieldValues);
+
+    SWSS_LOG_INFO("Written default TX error monitor configuration to CONFIG_DB");
+}
 
 // Initialize port state to OK in state table
 void TxErrorOrch::initializePortState(const std::string &portAlias)
@@ -71,7 +87,6 @@ void TxErrorOrch::doTask(Consumer &consumer)
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
-        bool erase_from_queue = true;
         try
         {
             auto tuple = it->second;
@@ -85,41 +100,14 @@ void TxErrorOrch::doTask(Consumer &consumer)
                 {
                     if (fvField(fv) == "poll_interval")   
                     {
-                        int interval = std::stoi(fvValue(fv));
-                        if(interval<= 0)
-                        {
-                            SWSS_LOG_ERROR("Invalid poll_interval value, current interval value %d", m_pollInterval);
-                        }
-                        else
-                        {
-                            m_pollInterval = interval;
-                            SWSS_LOG_NOTICE("TX Error polling interval set to %d seconds", m_pollInterval);
-                            updateTimer(m_pollInterval);
-                        }
+                        configPollInterval(std::stoi(fvValue(fv))); 
                     }
                     else if (fvField(fv) == "threshold")
                     {
-                        int threshold = std::stoi(fvValue(fv));
-                        if(threshold<= 0)
-                        {
-                            SWSS_LOG_ERROR("Invalid threshold value, current threshold value %d", m_threshold);
-                        }
-                        else
-                        {
-                            m_threshold = threshold;
-                            SWSS_LOG_NOTICE("TX Error threshold set to %d", m_threshold);
-                        }
+                        configThreshold(std::stoi(fvValue(fv)));
                     }
                 }
             }
-
-            //optional - fix If a del command is addad to the cli
-            else if (op == DEL_COMMAND)
-            {
-                m_pollInterval = DEFAULT_POLL_INTERVAL_SEC;
-                m_threshold = DEFAULT_THRESHOLD;
-            }
-
         }
         catch (const std::exception& e)
         {
@@ -130,15 +118,7 @@ void TxErrorOrch::doTask(Consumer &consumer)
             SWSS_LOG_ERROR("Unknown exception was caught in the request parser");
         }
 
-
-        if (erase_from_queue)
-        {
-            it = consumer.m_toSync.erase(it);
-        }
-        else
-        {
-            ++it;
-        }
+        it = consumer.m_toSync.erase(it);
     }
 }
 
@@ -146,91 +126,116 @@ void TxErrorOrch::updateTimer(int interval)
 {
     SWSS_LOG_ENTER();
 
-    m_timer->stop();
-
     auto interv = timespec { .tv_sec = interval, .tv_nsec = 0 };
     m_timer->setInterval(interv);
     m_timer->reset();
-    m_timer->start();
 }
 
 // Timer callback: check TX error counters for all ports
 void TxErrorOrch::doTask(swss::SelectableTimer &timer)
 {
     SWSS_LOG_ENTER();
-
-    for (const auto& portPair : gPortsOrch->getAllPorts())
-    {
-        txErrorCounterCheck(portPair.second);
-    }
+    txErrorCountersCheck();
 }
-
-// Check TX error counter for a port and update status if threshold exceeded
-void TxErrorOrch::txErrorCounterCheck(const Port& port)
+  
+void TxErrorOrch::txErrorCountersCheck()
 {
     SWSS_LOG_ENTER();
 
-    if(port.m_type != Port::PHY) 
-        return;
+    map<string, Port> portsList = gPortsOrch->getAllPorts();
 
-    sai_object_id_t oid = port.m_port_id;
-
-    vector<FieldValueTuple> fieldValues;
-
-    if(!m_countersTable->get(sai_serialize_object_id(oid), fieldValues)){
-        SWSS_LOG_ERROR("Failed to get tx error counters for port %s", port.m_alias.c_str());
-        return;
-    }
-
-    uint64_t tx_errors = 0;
-    for(const auto& fv : fieldValues)
+    for (const auto& portPair : portsList)
     {
-        if(fvField(fv) =="SAI_PORT_STAT_IF_OUT_ERRORS")
+        auto port = portPair.second;
+
+        if (port.m_type != Port::PHY) 
+            continue;
+
+        sai_object_id_t oid = port.m_port_id;
+
+        vector<FieldValueTuple> fieldValues;
+
+        if (!m_countersTable->get(sai_serialize_object_id(oid), fieldValues))
         {
-            tx_errors = std::stoull(fvValue(fv));
-            break;
+            SWSS_LOG_ERROR("Failed to get tx error counters for port %s", port.m_alias.c_str());
+            continue;
+        }
+
+        uint64_t tx_errors = 0;
+        for (const auto& fv : fieldValues)
+        {
+            if (fvField(fv) == "SAI_PORT_STAT_IF_OUT_ERRORS")
+            {
+                tx_errors = std::stoull(fvValue(fv));
+                break;
+            }
+        }
+
+        if (tx_errors > static_cast<uint64_t>(m_threshold))
+        {
+            SWSS_LOG_DEBUG("TX Error counters for port %s exceeded threshold: %ld > %d", 
+                port.m_alias.c_str(), tx_errors, m_threshold);
+            updatePortStatus(port, "NOT_OK");
+        }
+        else if (tx_errors <= static_cast<uint64_t>(m_threshold))
+        {
+            SWSS_LOG_DEBUG("TX Error counters for port %s is below threshold: %ld <= %d", 
+                port.m_alias.c_str(), tx_errors, m_threshold);
+            updatePortStatus(port, "OK");
         }
     }
+}
 
-    if(tx_errors > static_cast<uint64_t>(m_threshold))
+void TxErrorOrch::configPollInterval(int pollInterval)
+{
+    SWSS_LOG_ENTER();
+
+    if(pollInterval<= 0)
     {
-        SWSS_LOG_NOTICE("TX Error counters for port %s exceeded threshold: %ld > %d", 
-            port.m_alias.c_str(), tx_errors, m_threshold);
-        updatePortStatusNotOk(port);
+        SWSS_LOG_ERROR("Invalid poll_interval value, current interval value %d", m_pollInterval);
     }
-
-    else if(tx_errors <= static_cast<uint64_t>(m_threshold))
+    else
     {
-        SWSS_LOG_NOTICE("TX Error counters for port %s is below threshold: %ld <= %d", 
-            port.m_alias.c_str(), tx_errors, m_threshold);
-        updatePortStatusOk(port);
+        m_pollInterval = pollInterval;
+        SWSS_LOG_NOTICE("TX Error polling interval set to %d seconds", m_pollInterval);
+        updateTimer(m_pollInterval);
+    }
+}
+  
+void TxErrorOrch::configThreshold(int threshold)
+{
+    SWSS_LOG_ENTER();
+
+    if(threshold<= 0)
+    {
+        SWSS_LOG_ERROR("Invalid threshold value, current threshold value %d", m_threshold);
+    }
+    else
+    {
+        m_threshold = threshold;
+        SWSS_LOG_NOTICE("TX Error threshold set to %d", m_threshold);
+        txErrorCountersCheck();
     }
 }
 
-// Mark port status as NOT_OK in state table
-void TxErrorOrch::updatePortStatusNotOk(const Port& port)
+void TxErrorOrch::updatePortStatus(const Port& port, string status)
 {
     SWSS_LOG_ENTER();
 
     vector<FieldValueTuple> fieldValues;
- 
-    fieldValues.emplace_back("status", "NOT_OK");
+    if(status == "OK")
+    {
+        fieldValues.emplace_back("status", "OK");
+    }
+    else if(status == "NOT_OK")
+    {
+        fieldValues.emplace_back("status", "NOT_OK");
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Invalid status value, current status value %s", status.c_str());
+        return;
+    }
     m_stateTable->set(port.m_alias, fieldValues);
-
-    SWSS_LOG_NOTICE("Marking port %s (OID: %s) as NOT_OK", port.m_alias.c_str(),
-                    sai_serialize_object_id(port.m_port_id).c_str());
-}
-
-// Mark port status as OK in state table
-void TxErrorOrch::updatePortStatusOk(const Port& port)
-{
-    SWSS_LOG_ENTER();
-
-    vector<FieldValueTuple> fieldValues;
- 
-    fieldValues.emplace_back("status", "OK");
-    m_stateTable->set(port.m_alias, fieldValues);
-
-    SWSS_LOG_NOTICE("Marking port %s (OID: %s) as OK", port.m_alias.c_str(),
-                    sai_serialize_object_id(port.m_port_id).c_str());
+    SWSS_LOG_NOTICE("Updated port %s status to %s", port.m_alias.c_str(), status.c_str());
 }

--- a/orchagent/txerrororch.cpp
+++ b/orchagent/txerrororch.cpp
@@ -234,3 +234,4 @@ void TxErrorOrch::updatePortStatus(const Port& port, string status)
     m_stateTable->set(port.m_alias, fieldValues);
     SWSS_LOG_NOTICE("Updated port %s status to %s", port.m_alias.c_str(), status.c_str());
 }
+

--- a/orchagent/txerrororch.h
+++ b/orchagent/txerrororch.h
@@ -44,3 +44,4 @@ private:
 };
 
 #endif
+

--- a/orchagent/txerrororch.h
+++ b/orchagent/txerrororch.h
@@ -7,11 +7,10 @@
 #include <memory>
 #include <vector>
 
-
 class TxErrorOrch: public Orch
 {
 public:
-    TxErrorOrch(DBConnector *configDb, DBConnector *stateDb,const std::vector<std::string> &tableNames);
+    TxErrorOrch(DBConnector *configDb, DBConnector *stateDb , string tableName);
     ~TxErrorOrch(void);
     void doTask(Consumer &consumer);
     void doTask(swss::SelectableTimer &timer);
@@ -23,9 +22,10 @@ private:
 
     std::shared_ptr<swss::DBConnector> m_countersDb;  
     std::shared_ptr<swss::Table> m_countersTable;     
-    std::shared_ptr<swss::Table> m_stateTable;    
+    std::shared_ptr<swss::Table> m_stateTable;   
+    std::shared_ptr<swss::Table> m_configTable; 
     
-    SelectableTimer* m_timer; ///should I use shared_ptr?
+    SelectableTimer* m_timer; 
     ExecutableTimer* m_executor;
 
     static const int DEFAULT_POLL_INTERVAL_SEC = 10;
@@ -34,11 +34,12 @@ private:
     int m_pollInterval;  
     int m_threshold;
 
-
+    void InitializeMonitorConfiguration();
     void updateTimer(int interval); 
-    void txErrorCounterCheck(const Port& port);
-    void updatePortStatusNotOk(const Port& port);    
-    void updatePortStatusOk(const Port& port);
+    void txErrorCountersCheck();
+    void configPollInterval(int pollInterval);
+    void configThreshold(int threshold);
+    void updatePortStatus(const Port& port, string status);
 };
 
 #endif

--- a/orchagent/txerrororch.h
+++ b/orchagent/txerrororch.h
@@ -1,0 +1,44 @@
+#ifndef TXERROR_ORCH_H
+#define TXERROR_ORCH_H
+
+#include "orch.h"
+#include "timer.h"
+#include "portsorch.h"
+#include <memory>
+#include <vector>
+
+
+class TxErrorOrch: public Orch
+{
+public:
+    TxErrorOrch(DBConnector *configDb, DBConnector *stateDb,const std::vector<std::string> &tableNames);
+    ~TxErrorOrch(void);
+    void doTask(Consumer &consumer);
+    void doTask(swss::SelectableTimer &timer);
+
+    void initializePortState(const std::string &portAlias);
+
+private:
+    swss::DBConnector *m_stateDb;
+
+    std::shared_ptr<swss::DBConnector> m_countersDb;  
+    std::shared_ptr<swss::Table> m_countersTable;     
+    std::shared_ptr<swss::Table> m_stateTable;    
+    
+    SelectableTimer* m_timer; ///should I use shared_ptr?
+    ExecutableTimer* m_executor;
+
+    static const int DEFAULT_POLL_INTERVAL_SEC = 10;
+    static const int DEFAULT_THRESHOLD = 10;
+
+    int m_pollInterval;  
+    int m_threshold;
+
+
+    void updateTimer(int interval); 
+    void txErrorCounterCheck(const Port& port);
+    void updatePortStatusNotOk(const Port& port);    
+    void updatePortStatusOk(const Port& port);
+};
+
+#endif

--- a/orchagent/txerrororch.h
+++ b/orchagent/txerrororch.h
@@ -6,6 +6,8 @@
 #include "portsorch.h"
 #include <memory>
 #include <vector>
+#include <map>
+#include <string>
 
 class TxErrorOrch: public Orch
 {
@@ -15,11 +17,7 @@ public:
     void doTask(Consumer &consumer);
     void doTask(swss::SelectableTimer &timer);
 
-    void initializePortState(const std::string &portAlias);
-
 private:
-    swss::DBConnector *m_stateDb;
-
     std::shared_ptr<swss::DBConnector> m_countersDb;  
     std::shared_ptr<swss::Table> m_countersTable;     
     std::shared_ptr<swss::Table> m_stateTable;   
@@ -33,6 +31,9 @@ private:
 
     int m_pollInterval;  
     int m_threshold;
+    
+    // Map to track last known state of each port (OK/NOT_OK)
+    std::map<sai_object_id_t, std::string> m_portStateMap;
 
     void InitializeMonitorConfiguration();
     void updateTimer(int interval); 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -162,7 +162,8 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/cfgmgr/coppmgr.cpp \
                 $(top_srcdir)/orchagent/twamporch.cpp \
                 $(top_srcdir)/orchagent/stporch.cpp \
-                $(top_srcdir)/orchagent/nexthopkey.cpp
+                $(top_srcdir)/orchagent/nexthopkey.cpp \
+                $(top_srcdir)/orchagent/txerrororch.cpp
 
 tests_SOURCES += $(FLEX_CTR_DIR)/flex_counter_manager.cpp $(FLEX_CTR_DIR)/flex_counter_stat_manager.cpp $(FLEX_CTR_DIR)/flow_counter_handler.cpp $(FLEX_CTR_DIR)/flowcounterrouteorch.cpp
 tests_SOURCES += $(DEBUG_CTR_DIR)/debug_counter.cpp $(DEBUG_CTR_DIR)/drop_counter.cpp


### PR DESCRIPTION
This PR implements a comprehensive TX error counters monitoring.

🔧 TxErrorOrch Agent (txerrororch.cpp & txerrororch.h)
Two main doTask() methods:
- doTask(Consumer &consumer) - Handles configuration changes:
Listens to TX_ERROR_MONITOR table in CONFIG_DB
Updates polling interval and threshold parameters
Restarts timer with new interval when changed
- doTask(SelectableTimer &timer) - Performs periodic monitoring:
Triggered every poll_interval seconds (default: 10s)
Reads SAI_PORT_STAT_IF_OUT_ERRORS from COUNTERS_DB for all physical ports
Compares TX error count against threshold (default: 10)
Updates port status in STATE_DB: "OK" or "NOT_OK"

🔄 Integration Points
OrchDaemon: Creates gTxErrorOrch instance and adds to orchestration list.
PortsOrch: Initializes TX error state to "OK" when ports come online.
Build: Added to Makefile.am for compilation.
